### PR TITLE
Add pstore and cgroup to list of system filesystems

### DIFF
--- a/src/plugins/fs_usage/fs_usage.go
+++ b/src/plugins/fs_usage/fs_usage.go
@@ -20,6 +20,8 @@ var SYSTEM_FILESYSTEMS = []string{
 	"devpts",
 	"tmpfs",
 	"fuse",
+	"pstore",
+	"cgroup",
 }
 
 const MTAB = "/etc/mtab"


### PR DESCRIPTION
These filesystems should be excluded from metric collection.